### PR TITLE
ci: semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+      - next
+      - beta
+      - "*.x" # maintenance releases
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.PROBOTBOT_NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
   },
   "devDependencies": {
     "eslint": "^6.5.1",
-    "eslint-plugin-import": "^2.18.2",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "semantic-release": "^17.1.1"
   },
   "engines": {
     "node": ">= 8.3.0"


### PR DESCRIPTION
This sets up continuous releases using `semantic-release` like in the other probot/* repos